### PR TITLE
Exclude `lib/rubocop-foo.rb` from Naming/FileName cop

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -79,6 +79,12 @@ module RuboCop
             --require spec_helper
           TEXT
 
+          put '.rubocop.yml', <<~YML
+            Naming/FileName:
+             Exclude:
+               - lib/#{name}.rb
+          YML
+
           patch "lib/#{dirname}.rb", /^  end\nend/, <<~RUBY
                 PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
                 CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'default.yml').freeze


### PR DESCRIPTION
After initial generation, RuboCop finds an issue with the generated repo that nudges the author to violate gem naming conventions. See naming conventions here:

https://guides.rubygems.org/name-your-gem/

And post-generation disabling eg here:

https://github.com/rubocop-hq/rubocop-rails/blob/72c0fdd7b32083fa936780424db6eea31d75194b/.rubocop.yml#L86