### PR TITLE
Improve CLI

### DIFF
--- a/lib/rubocop/extension/generator/cli.rb
+++ b/lib/rubocop/extension/generator/cli.rb
@@ -4,6 +4,8 @@ module RuboCop
       class CLI
         BANNER = <<~TEXT
           Usage: rubocop-extension-generator NAME
+
+          The NAME must start with rubocop-, like rubocop-rspec.
         TEXT
 
         def self.run(argv)
@@ -20,9 +22,15 @@ module RuboCop
           args = opt.parse(@argv)
 
           name = args.first
-          raise "It must be named `rubocop-*`. For example: rubocop-rspec" unless name.match?(/\Arubocop-\w+\z/)
+          fail!(opt) unless name
+          fail!(opt) unless name.match?(/\Arubocop-\w+\z/)
 
           Generator.new(name).generate
+        end
+
+        private def fail!(opt)
+          puts opt.help
+          exit 1
         end
       end
     end

--- a/lib/rubocop/extension/generator/cli.rb
+++ b/lib/rubocop/extension/generator/cli.rb
@@ -19,6 +19,7 @@ module RuboCop
         def run
           # For --help
           opt = OptionParser.new(BANNER)
+          opt.version = VERSION
           args = opt.parse(@argv)
 
           name = args.first


### PR DESCRIPTION
This pull request has two improvements for the CLI.


First, it improves `--help` option output. 7371ae3
Currently, it uses `raise`, but I think it is not appropriate because it displays unnecessary stack traces.
So I replaced it with `puts` and `exit 1`.
And it did not handle executing the command without any arguments. So this change also adds handling it.






Second, it enables `--version` option. c4d151e

