### PR TITLE
Support nested config requires

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -18,9 +18,9 @@ module RuboCop
             require_relative '#{dirname}/version'
             require_relative '#{dirname}/inject'
 
-            RuboCop::#{classname}::Inject.defaults!
-
             require_relative '#{cops_file_name.sub(/\.rb$/, '').sub(/^lib\//, '')}'
+
+            RuboCop::#{classname}::Inject.defaults!
           RUBY
 
           put "lib/#{dirname}/inject.rb", <<~RUBY
@@ -35,9 +35,7 @@ module RuboCop
                 module Inject
                   def self.defaults!
                     path = CONFIG_DEFAULT.to_s
-                    hash = ConfigLoader.send(:load_yaml_configuration, path)
-                    config = Config.new(hash, path)
-                    puts "configuration from \#{path}" if ConfigLoader.debug?
+                    config = ConfigLoader.load_file(path)
                     config = ConfigLoader.merge_with_default(config, path)
                     ConfigLoader.instance_variable_set(:@default_configuration, config)
                   end

--- a/smoke/smoke.rb
+++ b/smoke/smoke.rb
@@ -22,7 +22,16 @@ Dir.mktmpdir('-rubocop-extension-generator-smoke') do |base_dir|
 
   gemspec_path.write gemspec
 
+  config_path = gem_dir / '.rubocop.yml'
+  config_path.write config_path.read + <<~CONFIG
+    require: rubocop-smoke
+
+    Smoke/Foo:
+      Enabled: true
+  CONFIG
+
   system('bundle', 'install', exception: true, chdir: gem_dir)
   system('bundle', 'exec', 'rake', 'new_cop[Smoke/Foo]', exception: true, chdir: gem_dir)
+  system('bundle', 'exec', 'rubocop', '--display-only-fail-level-offenses', '--fail-level', 'F', exception: true, chdir: gem_dir)
   system('bundle', 'exec', 'rake', 'spec', exception: true, chdir: gem_dir)
 end


### PR DESCRIPTION
Passing the extension's config through `ConfigLoader.load_file`, rather than using the private `load_yaml_configuration` method, ensures that `require` / `inherit_from` declarations are handled properly.

By loading the extensions additional `Cop` definitions prior to loading the config allow extensions to then "dogfood" by using the new cops/behaviours in their own `RuboCop` config.