### PR TITLE
Fix gem generation and smoke test run.

### DIFF
--- a/smoke/smoke.rb
+++ b/smoke/smoke.rb
@@ -9,6 +9,7 @@ load_path = File.expand_path('../lib', __dir__)
 Dir.mktmpdir('-rubocop-extension-generator-smoke') do |base_dir|
   base_dir = Pathname(base_dir)
   gem_name = 'rubocop-smoke'
+  gem_namespace = gem_name.sub('-', '/')
   gem_dir = base_dir / gem_name
 
   system({ 'RUBYLIB' => load_path }, 'ruby', exe_path, gem_name, exception: true, chdir: base_dir)
@@ -22,7 +23,13 @@ Dir.mktmpdir('-rubocop-extension-generator-smoke') do |base_dir|
 
   gemspec_path.write gemspec
 
+  spec = gem_dir / "spec/#{gem_namespace}_spec.rb"
+  specfile = spec.read
+  specfile.gsub!('expect(false).to eq(true)', 'expect(true).to eq(true)')
+
+  spec.write specfile
+
   system('bundle', 'install', exception: true, chdir: gem_dir)
   system('bundle', 'exec', 'rake', 'new_cop[Smoke/Foo]', exception: true, chdir: gem_dir)
-  system('bundle', 'exec', 'rake', 'spec', exception: true, chdir: gem_dir)
+  system('bundle', 'exec', 'rspec', exception: true, chdir: gem_dir)
 end

--- a/smoke/smoke.rb
+++ b/smoke/smoke.rb
@@ -31,5 +31,5 @@ Dir.mktmpdir('-rubocop-extension-generator-smoke') do |base_dir|
 
   system('bundle', 'install', exception: true, chdir: gem_dir)
   system('bundle', 'exec', 'rake', 'new_cop[Smoke/Foo]', exception: true, chdir: gem_dir)
-  system('bundle', 'exec', 'rspec', exception: true, chdir: gem_dir)
+  system('bundle', 'exec', 'rake', 'spec', exception: true, chdir: gem_dir)
 end


### PR DESCRIPTION
The newer version of bundle (e.g. 2.1.4) seems to have new option
to automatically include either rspec or minitest, e.g. via:

```
BUNDLE_GEM__TEST: "rspec"
```

Check existing `gem 'rspec'` declaration and skip Gemfile patching
if it's exist.

Also fix smoke test to patch the spec first so we can have success
rspec run again.