### PR TITLE
Fixed. `rake new_cop` doesn't work since rubocop v1.22.0

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -122,10 +122,7 @@ module RuboCop
                 exit!
               end
 
-              github_user = `git config github.user`.chop
-              github_user = 'your_id' if github_user.empty?
-
-              generator = RuboCop::Cop::Generator.new(cop_name, github_user)
+              generator = RuboCop::Cop::Generator.new(cop_name)
 
               generator.write_source
               generator.write_spec

--- a/rubocop-extension-generator.gemspec
+++ b/rubocop-extension-generator.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency 'rubocop', '>= 1.22.0'
   spec.add_runtime_dependency 'bundler'
   spec.add_runtime_dependency 'activesupport'
 end


### PR DESCRIPTION
Arguments of `RuboCop::Cop::Generator#initialize` are changed since rubocop v1.22.0.

c.f. 

* https://github.com/rubocop/rubocop/pull/10109
* https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#1220-2021-09-29

Therefore, `Rakefile` generated by this gem was broken, so I fixed this.

# Backtrace
```
$ bundle exec rake new_cop[Foo/Bar]
rake aborted!
ArgumentError: wrong number of arguments (given 2, expected 1)
/path/to/my-cop/vendor/bundle/ruby/3.1.0/gems/rubocop-1.24.1/lib/rubocop/cop/generator.rb:114:in `initialize'
/path/to/my-cop/Rakefile:30:in `new'
/path/to/my-cop/Rakefile:30:in `block in <top (required)>'
/path/to/my-cop/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/Users/sue445/.rbenv/versions/3.1.0/bin/bundle:23:in `load'
/Users/sue445/.rbenv/versions/3.1.0/bin/bundle:23:in `<main>'
Tasks: TOP => new_cop
(See full trace by running task with --trace)
```

# Version
```
$ bundle exec rubocop -V
1.24.1 (using Parser 3.1.0.0, rubocop-ast 1.15.1, running on ruby 3.1.0 x86_64-darwin21)
  - rubocop-performance 1.13.1
```