### PR TITLE
Fix CLI error caused by bundler newer than v2.3.9

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -137,7 +137,11 @@ module RuboCop
             gem 'rspec'
           RUBY
 
-          patch 'README.md', /^gem '#{name}'$/, "gem '#{name}', require: false"
+          if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.3.9')
+            patch 'README.md', /\$ bundle add #{name}$/, "\$ bundle add #{name} --require=false"
+          else
+            patch 'README.md', /^gem '#{name}'$/, "gem '#{name}', require: false"
+          end
 
           puts
           puts <<~MESSAGE


### PR DESCRIPTION
Fixes #15.

Since Bundler version 2.3.9, the string `gem name` is no longer included in the README.
So added condition for bundler's version and support newer instruction to add gem to Gemfile.

ref: https://github.com/rubygems/rubygems/pull/5337