### PR TITLE
Add missing `require bundler`

### DIFF
--- a/lib/rubocop/extension/generator.rb
+++ b/lib/rubocop/extension/generator.rb
@@ -5,6 +5,8 @@ require "rubocop/extension/generator/generator"
 require 'active_support'
 require 'active_support/core_ext/string/inflections'
 
+require 'bundler'
+
 require 'optparse'
 require 'pathname'
 require 'fileutils'


### PR DESCRIPTION
Follow up #16.

Sorry, v0.5.0 is now buggy.
I was checking the behavior from `bin/console`, and didn't notice the missing code.

This time I did `bundle exec rake build` and then `gem install pkg/rubocop-extension-generator-0.5.0.gem`, so I think it should be ok 😅 