### PR TITLE
Add `require` for InternalAffairs cop to .rubocop.yml with a generator

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -80,6 +80,9 @@ module RuboCop
           TEXT
 
           put '.rubocop.yml', <<~YML
+            require:
+              - rubocop/cop/internal_affairs
+
             Naming/FileName:
              Exclude:
                - lib/#{name}.rb


### PR DESCRIPTION
This PR is add `require` for InternalAffairs cop to .rubocop.yml with a generator.

The following settings are added.

```yaml
require:
  - rubocop/cop/internal_affairs
```