### PR TITLE
Support `bundle gem` gem name placeholder

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -138,7 +138,7 @@ module RuboCop
           RUBY
 
           if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.3.9')
-            patch 'README.md', /\$ bundle add #{name}$/, "\$ bundle add #{name} --require=false"
+            patch 'README.md', /\$ bundle add (.*)$/, '$ bundle add \1 --require=false'
           else
             patch 'README.md', /^gem '#{name}'$/, "gem '#{name}', require: false"
           end


### PR DESCRIPTION
Bundler 2.4.0 changed[^1] `bundle gem my-gem-name` from generating

    Install the gem and add to the application's Gemfile by executing:

        $ bundle add my-gem-name

to

    Install the gem and add to the application's Gemfile by executing:

        $ bundle add UPDATE_WITH_YOUR_GEM_NAME_PRIOR_TO_RELEASE_TO_RUBYGEMS_ORG

which breaks the extension generator:

```
Cannot apply patch for rubocop-example/README.md because (?-mix:\$ bundle add rubocop-example$) is missing
```

We can be compatible with both by simply capturing whatever was generated, and referencing it using a back reference.

```ruby
'$ bundle add example'.sub(/\$ bundle add (.*)$/, '$ bundle add \1 --require=false')
# => '$ bundle add example --require=false'
```

[^1]: See rubygems/rubygems#6093