### PR TITLE
Pass `--linter=rubocop --test=rspec` to `bundle gem`

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -7,7 +7,7 @@ module RuboCop
         end
 
         def generate
-          system('bundle', 'gem', name, exception: true)
+          system('bundle', 'gem', '--test=rspec',  name, exception: true)
 
           put "lib/#{name}.rb", <<~RUBY
             # frozen_string_literal: true
@@ -131,10 +131,6 @@ module RuboCop
 
               puts generator.todo
             end
-          RUBY
-
-          patch 'Gemfile', /\z/, <<~RUBY
-            gem 'rspec'
           RUBY
 
           if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.3.9')

--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -7,7 +7,7 @@ module RuboCop
         end
 
         def generate
-          system('bundle', 'gem', '--test=rspec',  name, exception: true)
+          system('bundle', 'gem', '--linter=rubocop', '--test=rspec',  name, exception: true)
 
           put "lib/#{name}.rb", <<~RUBY
             # frozen_string_literal: true


### PR DESCRIPTION
The generator expects to patch RSpec files, so specifying anything other than `rspec` as the test framework would break generation. Therefore, it makes sense to specify it ourselves, and save the user the time of having to select it.

It also seems very unlikely that someone would want to generate a RuboCop extension, but use a linter other than RuboCop, so let's save the user the time.