### PR TITLE
Patch missing `require 'yaml'` in file using YAML

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -85,6 +85,11 @@ module RuboCop
                - lib/#{name}.rb
           YML
 
+          patch "lib/#{dirname}.rb", %r{^require.*/version.$}, <<~RUBY.chomp
+            \\0
+            require 'yaml'
+          RUBY
+
           patch "lib/#{dirname}.rb", /^  end\nend/, <<~RUBY
                 PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
                 CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'default.yml').freeze


### PR DESCRIPTION
Since we use the `YAML` constant, it would be best practice to `require 'yaml'`, even if _technically_ the fact that we `require 'rubocop'` means that's probably happened already.

Added this after noticing some generated extensions add in `require "yaml"`, so perhaps they ran into an issue.