### PR TITLE
Fix uninitialized constant `YAML` when running `./bin/console`

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -85,6 +85,12 @@ module RuboCop
                - lib/#{name}.rb
           YML
 
+          patch "lib/#{dirname}.rb", /^# frozen_string_literal: true\n/, <<~RUBY
+          # frozen_string_literal: true
+
+          require 'yaml'
+          RUBY
+
           patch "lib/#{dirname}.rb", /^  end\nend/, <<~RUBY
                 PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
                 CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'default.yml').freeze


### PR DESCRIPTION
I'm getting this error when running `./bin/console` on a generated extension:
```
Traceback (most recent call last):
        4: from ./bin/console:5:in `<main>'
        3: from ./bin/console:5:in `require'
        2: from /home/gustavoribeiro/Development/personal/rubocop-coupling/lib/rubocop/coupling.rb:7:in `<top (required)>'
        1: from /home/gustavoribeiro/Development/personal/rubocop-coupling/lib/rubocop/coupling.rb:8:in `<module:RuboCop>'
/home/gustavoribeiro/Development/personal/rubocop-coupling/lib/rubocop/coupling.rb:13:in `<module:Coupling>': uninitialized constant RuboCop::Coupling::YAML (NameError)
```
Looks like we need to require the `YAML` library:

https://github.com/rubocop/rubocop-extension-generator/assets/57065994/390cf43f-bf60-4c00-a2f2-37c1254ae4f4

To fix the error, I added a `patch` in `lib/rubocop/extension/generator/generator.rb` to import the `YAML` .