### PR TITLE
Fix error with RuboCop capitalization in specs

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -95,10 +95,6 @@ module RuboCop
             end
           RUBY
 
-          patch "lib/#{dirname}.rb", 'module Rubocop', 'module RuboCop'
-          patch "lib/#{dirname}/version.rb", 'module Rubocop', 'module RuboCop'
-          patch "#{name}.gemspec", 'Rubocop', 'RuboCop'
-
           patch "#{name}.gemspec", /^end/, <<~RUBY
 
               spec.add_runtime_dependency 'rubocop'
@@ -133,9 +129,9 @@ module RuboCop
             end
           RUBY
 
-          patch 'Gemfile', /\z/, <<~RUBY
-            gem 'rspec'
-          RUBY
+          patch_all "**/*.rb", 'Rubocop', 'RuboCop'
+
+          patch "#{name}.gemspec", 'Rubocop', 'RuboCop'
 
           if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.3.9')
             patch 'README.md', /\$ bundle add (.*)$/, '$ bundle add \1 --require=false'
@@ -165,6 +161,14 @@ module RuboCop
           file = path.read
           raise "Cannot apply patch for #{path} because #{pattern} is missing" unless file.match?(pattern)
           path.write file.sub(pattern, replacement)
+        end
+
+        private def patch_all(glob, pattern, replacement)
+          Dir[root_path / glob].each do |path|
+            if File.read(path).match(pattern)
+              patch(path.sub(root_path.to_s, '').sub(%r|^/|, ''), pattern, replacement)
+            end
+          end
         end
 
         private def root_path

--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -155,18 +155,18 @@ module RuboCop
           path.write(content)
         end
 
-        private def patch(path, pattern, replacement)
+        private def patch(path, pattern, replacement, all: false)
           puts "update #{path}"
           path = root_path / path
           file = path.read
           raise "Cannot apply patch for #{path} because #{pattern} is missing" unless file.match?(pattern)
-          path.write file.sub(pattern, replacement)
+          path.write(all ? file.gsub(pattern, replacement) : file.sub(pattern, replacement))
         end
 
         private def patch_all(glob, pattern, replacement)
           Dir[root_path / glob].each do |path|
             if File.read(path).match(pattern)
-              patch(path.sub(root_path.to_s, '').sub(%r|^/|, ''), pattern, replacement)
+              patch(path.sub(root_path.to_s, '').sub(%r|^/|, ''), pattern, replacement, all: true)
             end
           end
         end

--- a/smoke/smoke.rb
+++ b/smoke/smoke.rb
@@ -2,6 +2,8 @@
 
 require 'tmpdir'
 require 'pathname'
+require 'open3'
+require 'json'
 
 exe_path = File.expand_path('../exe/rubocop-extension-generator', __dir__)
 load_path = File.expand_path('../lib', __dir__)
@@ -24,5 +26,21 @@ Dir.mktmpdir('-rubocop-extension-generator-smoke') do |base_dir|
 
   system('bundle', 'install', exception: true, chdir: gem_dir)
   system('bundle', 'exec', 'rake', 'new_cop[Smoke/Foo]', exception: true, chdir: gem_dir)
-  system('bundle', 'exec', 'rake', 'spec', exception: true, chdir: gem_dir)
+
+  stdout, status = Open3.capture2(
+    { 'SPEC_OPTS' => '--format json' },
+    *['bundle', 'exec', 'rake', 'spec'],
+    chdir: gem_dir,
+  )
+  stdout_json = stdout.lines.find { |l| l.start_with?('{') }
+  failures = JSON.parse(stdout_json)['examples'].select { |example| example['status'] == 'failed' }
+
+  unexpected_failures = failures.map { |failure| failure['full_description'] } - [
+    'RuboCop::Smoke has a version number',
+    'RuboCop::Smoke does something useful',
+    'RuboCop::Cop::Smoke::Foo registers an offense when using `#bad_method`',
+  ]
+  if !unexpected_failures.empty?
+    raise "rspec failed. Unknown failures:\n#{unexpected_failures.join("\n")}"
+  end
 end


### PR DESCRIPTION
Update smoke tests to run, and pass for known failures

In the same spirit as https://github.com/rubocop/rubocop-extension-generator/pull/20, this was my attempt to get the smoke tests working

- There are a few "expected" failures in a fresh gem (such as `expect(true).to eq(false)`) so this attempts to allow those and only fail on unknown issues (such as RuboCop capitalization errors)
