### PR TITLE
Prevent errors when internally using cops that rely on configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master (unreleased)
 
+## v0.6.1
+
+* [#28](https://github.com/rubocop/rubocop-extension-generator/pull/28): Prevent errors when internally using cops that rely on configuration options.
+
 ## v0.6.0
 
 * [#27](https://github.com/rubocop/rubocop-extension-generator/pull/27): Support RuboCop extension plugin.

--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -91,6 +91,7 @@ module RuboCop
           put '.rubocop.yml', <<~YML
             plugins:
               - rubocop-internal_affairs
+              - #{name}
 
             Naming/FileName:
               Exclude:


### PR DESCRIPTION
This PR prevents errors when internally using cops that rely on configuration options.

Please see here for details: https://github.com/rubocop/rubocop-capybara/pull/144#issuecomment-2700070035