### PR TITLE
fix: Support both README.md formats for bundle add command

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -146,7 +146,7 @@ module RuboCop
           RUBY
 
           if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.3.9')
-            patch 'README.md', /\$ bundle add (.*)$/, '$ bundle add \1 --require=false'
+            patch 'README.md', /(\$ |^)bundle add (.*)$/, '\1bundle add \2 --require=false'
           else
             patch 'README.md', /^gem '#{name}'$/, "gem '#{name}', require: false"
           end


### PR DESCRIPTION
The README.md format generated by `bundle gem` has been changed to omit the `$` prefix for shell commands. This patch updates the generator to support both patterns:
- `$ bundle add ...`
- `bundle add ...`

This fixes the error:

```
Cannot apply patch for rubocop-foo/README.md because (?-mix:\\$ bundle add (.*)$) is missing
```

## Expected behavior
The generator should successfully update README.md regardless of the bundle command format:

When README.md contains commands with $ prefix:
`$ bundle add rubocop-foo`


When README.md contains commands without $ prefix:
`bundle add rubocop-foo`

Both patterns should be recognized and properly processed by the generator.


## Actual behavior

```shell
$ rubocop-extension-generator rubocop-foo
.
.
.
update README.md
/home/lee266.linux/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-extension-generator-0.6.1/lib/rubocop/extension/generator/generator.rb:178:in `patch': Cannot apply patch for rubocop-foo/README.md because (?-mix:\\$ bundle add (.*)$) is missing (RuntimeError)
        from /home/lee266.linux/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-extension-generator-0.6.1/lib/rubocop/extension/generator/generator.rb:149:in `generate'
        from /home/lee266.linux/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-extension-generator-0.6.1/lib/rubocop/extension/generator/cli.rb:31:in `run'
        from /home/lee266.linux/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-extension-generator-0.6.1/lib/rubocop/extension/generator/cli.rb:14:in `run'
        from /home/lee266.linux/.rbenv/versions/3.1.6/lib/ruby/gems/3.1.0/gems/rubocop-extension-generator-0.6.1/exe/rubocop-extension-generator:6:in `<top (required)>'
        from /home/lee266.linux/.rbenv/versions/3.1.6/bin/rubocop-extension-generator:25:in `load'
        from /home/lee266.linux/.rbenv/versions/3.1.6/bin/rubocop-extension-generator:25:in `<main>'

```

## Enviorments

```shell
$ bundle -v
Bundler version 2.6.6
$ rubocop-extension-generator -v
rubocop-extension-generator 0.6.1
```