### PR TITLE
Handle changes to the gem install declaration in Bundler's generated README

### DIFF
--- a/lib/rubocop/extension/generator/generator.rb
+++ b/lib/rubocop/extension/generator/generator.rb
@@ -145,8 +145,10 @@ module RuboCop
             gem 'rspec'
           RUBY
 
+          # Bundler's generated README.md has had 2 styles of gem declarations.
+          # See: https://github.com/rubygems/rubygems/commit/c805e9b558
           if Gem::Version.new(Bundler::VERSION) >= Gem::Version.new('2.3.9')
-            patch 'README.md', /\$ bundle add (.*)$/, '$ bundle add \1 --require=false'
+            patch 'README.md', /^\s*(?:\$\s*)?bundle add[^\n]*$/, '\0 --require=false'
           else
             patch 'README.md', /^gem '#{name}'$/, "gem '#{name}', require: false"
           end


### PR DESCRIPTION
The extension generator was failing for me on the latest version of Bundler, because the README format shifted and no longer matched the expectation for how gems are declared in the install guide.

See: https://github.com/rubygems/rubygems/commit/c805e9b558